### PR TITLE
Adding the 'coupon' key to the item object in order to track coupon codes

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -179,7 +179,8 @@ const mapProductData = i => {
     price: i.price,
     item_brand: i.brand,
     item_variant: i.variant,
-    quantity: i.quantity ? math.round(i.quantity) : i.quantity
+    quantity: i.quantity ? math.round(i.quantity) : i.quantity,
+    coupon: i.coupon
   };
   category.forEach((c, i) => {
     if (i === 0) itemObj.item_category = c;


### PR DESCRIPTION
Add the 'coupon' key to itemObj according to the example on https://developers.google.com/analytics/devguides/collection/ga4/ecommerce#begin_checkout in order to track coupon codes associated with a product.